### PR TITLE
Ignore double colons in fuzzy finds

### DIFF
--- a/lib/fuzzy-finder-view.coffee
+++ b/lib/fuzzy-finder-view.coffee
@@ -221,6 +221,8 @@ class FuzzyFinderView extends SelectListView
 
   getFilterQuery: ->
     query = super
+    # Help rails developers + don't match double colons as colon-line-number
+    query = query.replace(/::/g, '')
     colon = query.indexOf(':')
     query = query[0...colon] if colon isnt -1
     # Normalize to backslashes on Windows
@@ -229,6 +231,7 @@ class FuzzyFinderView extends SelectListView
 
   getLineNumber: ->
     query = @filterEditorView.getText()
+    query = query.replace(/::/g, '')
     colon = query.indexOf(':')
     if colon is -1
       -1

--- a/spec/fuzzy-finder-spec.coffee
+++ b/spec/fuzzy-finder-spec.coffee
@@ -787,6 +787,26 @@ describe 'FuzzyFinder', ->
       expect(secondaryMatches.first().text()).toBe 'root-dir'
       expect(secondaryMatches.last().text()).toBe 'sample'
 
+    it "highlights matches in the directory and file name", ->
+      bufferView.items = [
+        {
+          filePath: '/test/root-dir1/sample.js'
+          projectRelativePath: 'root-dir1/sample.js'
+        }
+      ]
+      bufferView.filterEditorView.getModel().setText('root-dir::sample')
+      bufferView.populateList()
+      resultView = bufferView.getSelectedItemView()
+
+      primaryMatches = resultView.find('.primary-line .character-match')
+      expect(primaryMatches.length).toBe 1
+      expect(primaryMatches.last().text()).toBe 'sample'
+
+      secondaryMatches = resultView.find('.secondary-line .character-match')
+      expect(secondaryMatches.length).toBe 2
+      expect(secondaryMatches.first().text()).toBe 'root-dir'
+      expect(secondaryMatches.last().text()).toBe 'sample'
+
     describe "when the filter text doesn't have a file path", ->
       it "moves the cursor in the active editor to that line number", ->
         [editor1, editor2] = atom.workspace.getTextEditors()


### PR DESCRIPTION
Currently everything after the first colon is
ignored because it is expecting a line number

Rails developers often fuzzy find for things like
Parse::Education (which will usually have a file 
at parse/education.rb)

This fix drops double colons, because it fixes a
bug, helps fuzzy finds for Rails devs, doesn’t 
hurt others (who puts :: in their file paths?)

I know this isn't just an editor for rails developers, so let me know the honest feedback. :+1: 
